### PR TITLE
Exclude layer in obfuscation support

### DIFF
--- a/Scripts/KannaProteccController.cs
+++ b/Scripts/KannaProteccController.cs
@@ -45,7 +45,7 @@ namespace Kanna.Protecc
                 ValidateClip(gameObject, controller, i);
             }
 
-            var meshRenderers = gameObject.GetComponentsInChildren<MeshRenderer>(true).Where(o => o?.sharedMaterials != null && o.sharedMaterials.Any(a => KannaProteccMaterial.IsShaderSupported(a.shader, out _))).ToArray();
+            var meshRenderers = gameObject.GetComponentsInChildren<MeshRenderer>(true).Where(o => o?.sharedMaterials != null && o.sharedMaterials.Any(a => a != null && KannaProteccMaterial.IsShaderSupported(a.shader, out _))).ToArray();
             foreach (var meshRenderer in meshRenderers)
             {
                 for (var i = 0; i < _clipsFalse.Length; ++i)
@@ -56,7 +56,7 @@ namespace Kanna.Protecc
                 }
             }
 
-            var skinnedMeshRenderers = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>(true).Where(o => o?.sharedMaterials != null && o.sharedMaterials.Any(a => KannaProteccMaterial.IsShaderSupported(a.shader, out _))).ToArray();
+            var skinnedMeshRenderers = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>(true).Where(o => o?.sharedMaterials != null && o.sharedMaterials.Any(a => a != null && KannaProteccMaterial.IsShaderSupported(a.shader, out _))).ToArray();
             foreach (var skinnedMeshRenderer in skinnedMeshRenderers)
             {
                 for (var i = 0; i < _clipsFalse.Length; ++i)

--- a/Scripts/KannaProteccRoot.cs
+++ b/Scripts/KannaProteccRoot.cs
@@ -67,6 +67,9 @@ namespace Kanna.Protecc
         public List<string> excludeParamNames = new List<string>();
 
         [SerializeField]
+        public List<VRCAvatarDescriptor.AnimLayerType> excludeAnimatorLayers = new List<VRCAvatarDescriptor.AnimLayerType>();
+
+        [SerializeField]
         public StringStringSerializableDictionary ParameterRenamedValues = new StringStringSerializableDictionary();
 
         public string GetBitKeyName(int id, int LimitRenameLength = -1)

--- a/Scripts/Obfuscator.cs
+++ b/Scripts/Obfuscator.cs
@@ -128,7 +128,11 @@ namespace Kanna.Protecc
                 var animationLayers = avatar.baseAnimationLayers;
                 for (var i = 0; i < animationLayers.Length; ++i)
                 {
-                    if (animationLayers[i].animatorController == null || ((AnimatorController)animationLayers[i].animatorController).name.ToLower().Contains("gogo") || root.excludeObjectNames.Any(z => z == (AnimatorController)animationLayers[i].animatorController)) continue;
+                    if (animationLayers[i].animatorController == null ||
+                        root.excludeAnimatorLayers.Contains(animationLayers[i].type) ||
+                        root.excludeObjectNames.Any(z => z == (AnimatorController)animationLayers[i].animatorController))
+                            continue;
+
                     var animator = animationLayers[i].animatorController;
                     animationLayers[i].animatorController = AnimatorObfuscator((AnimatorController)animator, root);
                 }
@@ -139,7 +143,11 @@ namespace Kanna.Protecc
                 var specialAnimationLayers = avatar.specialAnimationLayers;
                 for (var i = 0; i < specialAnimationLayers.Length; ++i)
                 {
-                    if (specialAnimationLayers[i].animatorController == null || ((AnimatorController)specialAnimationLayers[i].animatorController).name.ToLower().Contains("gogo") || root.excludeObjectNames.Any(z => z == (AnimatorController)specialAnimationLayers[i].animatorController)) continue;
+                    if (specialAnimationLayers[i].animatorController == null ||
+                        root.excludeAnimatorLayers.Contains(specialAnimationLayers[i].type) ||
+                        root.excludeObjectNames.Any(z => z == (AnimatorController)specialAnimationLayers[i].animatorController))
+                            continue;
+                            
                     var animator = specialAnimationLayers[i].animatorController;
                     specialAnimationLayers[i].animatorController = AnimatorObfuscator((AnimatorController)animator, root);
                 }


### PR DESCRIPTION
This pull request (btw this is my first pull request, so i hope this is how we make one) aims to add a way to exclude certain animator layers when obfuscating with AntiRip, which is useful, for example, with locomotion addons. The current way is just to exclude a layer if it contains the string 'gogo', but this is too unreliable. With what I made, in the 'Obfuscator Settings' section of KannaProteccRoot, we can add layers to be excluded from obfuscation.
This uses enum values so it is independant of the actual layers in VRCAvatarDescriptor
![image](https://github.com/PlagueVRC/AntiRip/assets/34245959/ce1b56ce-907b-4890-9186-e46042b7f422)
Here for example I set it up so it stops messing with my locomotion controller
![image](https://github.com/PlagueVRC/AntiRip/assets/34245959/d4ad1eda-6db3-4852-b20b-72fe4adef091)
As you can see only the FX layer was obfuscated, and I think this is very cool, rad even.