### PR TITLE
Fix ui going out of bounds

### DIFF
--- a/Editor/KannaProteccRootEditor.cs
+++ b/Editor/KannaProteccRootEditor.cs
@@ -197,7 +197,7 @@ namespace Kanna.Protecc
                 GUI.backgroundColor = Color.green;
             }
 
-            if (GUILayout.Button(new GUIContent(!KannaProteccRoot.IsProtected ? (!IsVRCOpen ? "Protecc Avatar" : "Close VRChat To Encrypt") : "Un-Protecc Avatar", !KannaProteccRoot.IsProtected ? "Protecc's your avatar from rippers." : "Returns your avatar to its original form."), GUILayout.Height(Screen.width / 10f), GUILayout.Width((Screen.width / 2f) - 20f)))
+            if (GUILayout.Button(new GUIContent(!KannaProteccRoot.IsProtected ? (!IsVRCOpen ? "Protecc Avatar" : "Close VRChat To Encrypt") : "Un-Protecc Avatar", !KannaProteccRoot.IsProtected ? "Protecc's your avatar from rippers." : "Returns your avatar to its original form."), GUILayout.Height(Screen.width / 10f), GUILayout.ExpandWidth(true), GUILayout.MaxWidth(999999f)))
             {
                 if (KannaProteccRoot.IsProtected)
                 {
@@ -216,7 +216,7 @@ namespace Kanna.Protecc
 
             GUI.enabled = EncryptedObjExists && !IsVRCOpen;
 
-            if (GUILayout.Button(new GUIContent(!IsVRCOpen ? "Write Keys" : "Close VRChat To Write Keys", "Write your keys to saved attributes!"), GUILayout.Height(Screen.width / 10f), GUILayout.Width((Screen.width / 2f) - 20f)))
+            if (GUILayout.Button(new GUIContent(!IsVRCOpen ? "Write Keys" : "Close VRChat To Write Keys", "Write your keys to saved attributes!"), GUILayout.Height(Screen.width / 10f), GUILayout.ExpandWidth(true), GUILayout.MaxWidth(999999f)))
             {
                 KannaProteccRoot.WriteBitKeysToExpressions(GameObject.Find(KannaProteccRoot.gameObject.name.Trim() + "_KannaProteccted").GetComponent<VRCAvatarDescriptor>().expressionParameters, true, true);
             }
@@ -227,7 +227,7 @@ namespace Kanna.Protecc
 
             //Do the properties
             GUILayout.BeginHorizontal();
-            GUILayout.BeginVertical(GUILayout.Width((Screen.width / 2f) - 20f));
+            GUILayout.BeginVertical(GUILayout.ExpandWidth(true), GUILayout.MaxWidth(999999f));
             m_DistortRatioProperty.floatValue = GUILayout.HorizontalSlider(m_DistortRatioProperty.floatValue, .6f, 5f);
             GUILayout.Space(15);
             GUILayout.BeginHorizontal();
@@ -239,7 +239,7 @@ namespace Kanna.Protecc
             GUILayout.EndVertical();
 
             GUILayout.FlexibleSpace();
-            GUILayout.BeginVertical(GUILayout.Width((Screen.width / 2f) - 20f));
+            GUILayout.BeginVertical(GUILayout.ExpandWidth(true), GUILayout.MaxWidth(999999f));
             GUILayout.Space(3);
             GUILayout.Label("VRC Saved Paramters Path");
             m_VrcSavedParamsPathProperty.stringValue = EditorGUILayout.TextField(m_VrcSavedParamsPathProperty.stringValue);


### PR DESCRIPTION
In the current version, the 'write keys' button and the 'vrc saved parameters path' section are going out of bounds and sometimes don't even appear.
![b4](https://github.com/PlagueVRC/AntiRip/assets/34245959/78739c0f-8979-4434-afb0-b1c1a4a67094)
![image](https://github.com/PlagueVRC/AntiRip/assets/34245959/81e520ae-2fec-47db-bda4-aaaf192bc676)

Proposed solution is to let the editor choose the control's width automatically with GUILayout.ExpandWidth, and so it will split the controls in half and they will both appear. Result :
![after](https://github.com/PlagueVRC/AntiRip/assets/34245959/8396b2c0-1aea-4d54-96e2-5d526e6c980e)
